### PR TITLE
feat: track inventory and equipment

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -1,20 +1,35 @@
+#[derive(Clone, Debug, PartialEq)]
 pub struct Item {
+    name: String,
     weight: usize,
+    types: Vec<String>,
 }
 
 impl Item {
     #[must_use]
-    pub fn new(weight: usize) -> Self {
-        Item { weight }
+    pub fn new(name: impl Into<String>, weight: usize, types: Vec<String>) -> Self {
+        Item {
+            name: name.into(),
+            weight,
+            types,
+        }
+    }
+
+    pub fn get_name(&self) -> &str {
+        &self.name
     }
 
     #[must_use]
     pub fn get_weight(&self) -> usize {
         self.weight
     }
+
+    pub fn has_type(&self, item_type: impl Into<String>) -> bool {
+        self.types.contains(&item_type.into())
+    }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Items(Vec<Item>);
 
 impl Items {
@@ -42,9 +57,21 @@ mod tests {
     #[test]
     fn _should_accumulate_total_weight() {
         let items = Items(vec![
-            Item { weight: 1 },
-            Item { weight: 2 },
-            Item { weight: 3 },
+            Item {
+                name: String::from("one"),
+                weight: 1,
+                types: vec![],
+            },
+            Item {
+                name: String::from("two"),
+                weight: 2,
+                types: vec![],
+            },
+            Item {
+                name: String::from("three"),
+                weight: 3,
+                types: vec![],
+            },
         ]);
 
         assert_eq!(items.get_total_weight(), 6);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod item;
 pub mod modifiers;
 pub mod race;
 pub mod skill;
+pub mod slot;
 pub mod spell;
 pub mod utils;
 pub mod view;

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -1,0 +1,227 @@
+use std::{collections::HashMap, error, fmt};
+
+use crate::item::Item;
+
+#[derive(Debug)]
+pub struct Slot<T, F>
+where
+    F: Fn(&T) -> bool,
+{
+    value: Option<T>,
+    validator: F,
+}
+
+impl<T, F> Slot<T, F>
+where
+    F: Fn(&T) -> bool,
+{
+    pub fn new(validator: F) -> Self {
+        Self {
+            value: None,
+            validator,
+        }
+    }
+
+    pub fn equip(&mut self, value: T) -> SlotResult<()> {
+        if self.value.is_some() {
+            return Err(SlotError::Full);
+        }
+
+        if !(self.validator)(&value) {
+            return Err(SlotError::Invalid);
+        }
+
+        self.value = Some(value);
+
+        Ok(())
+    }
+
+    pub fn unequip(&mut self) -> SlotResult<T> {
+        self.value.take().ok_or(SlotError::Empty)
+    }
+}
+
+#[derive(Debug)]
+pub enum SlotError {
+    Full,
+    Empty,
+    Invalid,
+}
+
+impl fmt::Display for SlotError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let result = match self {
+            SlotError::Full => "Slot already contains something.".to_owned(),
+            SlotError::Empty => "Cannot remove something from empty Slot.".to_owned(),
+            SlotError::Invalid => "Attempted to equip invalid value.".into(),
+        };
+
+        write!(f, "{result}")
+    }
+}
+
+impl error::Error for SlotError {}
+
+pub type SlotResult<T> = Result<T, SlotError>;
+
+type ItemSlot = Slot<Item, fn(&Item) -> bool>;
+
+#[derive(Debug, Default)]
+pub struct ItemSlots(HashMap<String, ItemSlot>);
+
+impl ItemSlots {
+    pub fn add_slot(&mut self, slot_name: impl Into<String>, slot: Slot<Item, fn(&Item) -> bool>) {
+        self.0.insert(slot_name.into(), slot);
+    }
+
+    pub fn equip(&mut self, item: Item, slot_name: impl Into<String>) -> SlotsResult<()> {
+        let slot_name = slot_name.into();
+
+        self.0
+            .get_mut(&slot_name)
+            .ok_or(SlotsError::NotExists { slot: slot_name })
+            .and_then(|slot| slot.equip(item).map_err(Into::<SlotsError>::into))
+    }
+
+    pub fn unequip(&mut self, slot_name: impl Into<String>) -> SlotsResult<Item> {
+        let slot_name = slot_name.into();
+
+        self.0
+            .get_mut(&slot_name)
+            .ok_or(SlotsError::NotExists { slot: slot_name })
+            .and_then(|slot| slot.unequip().map_err(Into::<SlotsError>::into))
+    }
+
+    pub fn has_item_equipped_matching_criteria(&self, item_criteria: fn(&Item) -> bool) -> bool {
+        self.0
+            .values()
+            .filter_map(|slot| slot.value.as_ref())
+            .any(|item| item_criteria(item))
+    }
+}
+
+#[derive(Debug)]
+pub enum SlotsError {
+    NotExists { slot: String },
+    SlotProblem(SlotError),
+}
+
+impl From<SlotError> for SlotsError {
+    fn from(value: SlotError) -> Self {
+        SlotsError::SlotProblem(value)
+    }
+}
+
+impl fmt::Display for SlotsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let result = match self {
+            SlotsError::NotExists { slot } => format!("{slot} slot does not exist."),
+            SlotsError::SlotProblem(e) => e.to_string(),
+        };
+
+        write!(f, "{result}")
+    }
+}
+
+impl error::Error for SlotsError {}
+
+pub type SlotsResult<T> = Result<T, SlotsError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn _should_equip_if_valid() -> SlotResult<()> {
+        let mut vc = Slot::new(|item: &Item| item.has_type("armor"));
+
+        vc.equip(Item::new("one", 1, vec!["armor".into()]))?;
+
+        assert_eq!(vc.value, Some(Item::new("one", 1, vec!["armor".into()])));
+
+        Ok(())
+    }
+
+    #[test]
+    fn _should_return_err_if_equip_not_valid() {
+        let mut vc = Slot::new(|item: &Item| item.has_type("armor"));
+        let result = vc.equip(Item::new("not armor", 42, vec![]));
+
+        assert!(
+            matches!(result, Err(SlotError::Invalid)),
+            "Should return Err"
+        );
+    }
+
+    #[test]
+    fn _should_prevent_equipping_multiple_things_to_same_slot() {
+        let mut vc = Slot::new(|_: &Item| true);
+
+        let _ = vc.equip(Item::new("armor 1", 35, vec!["armor".into()]));
+
+        let result = vc.equip(Item::new("armor 2", 35, vec![String::from("armor")]));
+
+        assert!(matches!(result, Err(SlotError::Full)));
+    }
+
+    #[test]
+    fn _should_prevent_removing_from_empty_slot() {
+        let mut vc = Slot::new(|_: &Item| false);
+
+        assert!(matches!(vc.unequip(), Err(SlotError::Empty)));
+    }
+
+    #[test]
+    fn _should_return_stored_thing_on_unequip() -> SlotResult<()> {
+        let mut vc = Slot::new(|_: &Item| true);
+        let _ = vc.equip(Item::new("dummy", 0, vec![]));
+
+        assert_eq!(vc.unequip()?, Item::new("dummy", 0, vec![]));
+
+        Ok(())
+    }
+
+    #[test]
+    fn _should_remove_value_from_slot_on_unequip() -> SlotResult<()> {
+        let mut vc = Slot::new(|_: &Item| true);
+        vc.value = Some(Item::new("dummy", 0, vec![]));
+        let _ = vc.unequip()?;
+
+        assert_eq!(vc.value, None);
+
+        Ok(())
+    }
+
+    mod slots {
+        use super::*;
+
+        #[test]
+        fn _should_allow_equipping_to_multiple_slots() -> SlotsResult<()> {
+            let mut equipment = ItemSlots::default();
+            equipment.add_slot("armor", Slot::new(|item| item.has_type("armor")));
+            equipment.add_slot("right hand", Slot::new(|item| item.has_type("weapon")));
+
+            equipment.equip(Item::new("Chain Mail", 55, vec!["armor".into()]), "armor")?;
+            equipment.equip(Item::new("Rapier", 2, vec!["weapon".into()]), "right hand")?;
+
+            Ok(())
+        }
+
+        #[test]
+        fn _should_return_whether_contains_thing_of_given_type() -> SlotsResult<()> {
+            let mut equipment = ItemSlots::default();
+            equipment.add_slot("armor", Slot::new(|item| item.has_type("armor")));
+            equipment.add_slot("right hand", Slot::new(|item| item.has_type("weapon")));
+
+            let armor_criteria = |item: &Item| item.has_type("armor");
+
+            equipment.equip(Item::new("Rapier", 2, vec!["weapon".into()]), "right hand")?;
+            assert!(!equipment.has_item_equipped_matching_criteria(armor_criteria));
+
+            equipment.equip(Item::new("Chain Mail", 55, vec!["armor".into()]), "armor")?;
+            assert!(equipment.has_item_equipped_matching_criteria(armor_criteria));
+
+            Ok(())
+        }
+    }
+}

--- a/src/tui_test.rs
+++ b/src/tui_test.rs
@@ -11,6 +11,7 @@ use cygnus::{
     modifiers::Proficiency,
     race::{self, CreatureType, Language, Race, Size},
     skill::Skills,
+    slot::ItemSlots,
     spell::SpellList,
     view::tui::render_character,
 };
@@ -58,6 +59,7 @@ fn ui<B: Backend>(f: &mut Frame<B>) {
         items: Items::default(),
         exhaustion_level: 0,
         damage: 0,
+        equipment: ItemSlots::default(),
     };
     character.add_class(
         Class::try_from(class::Template {


### PR DESCRIPTION
- `User`s can select where each `Item` is equipped
- `Item`s can only be equipped to certain kinds of `Slot`s
- `Character`s can have `Slot`s of multiple types
- `Character`s can have multiple `Slot`s of the same type
- `Slot`s can only have a single `Item` at a time
- `Item`s can be unequipped from `Slot`s
- `Character`s can know if they have equipment of certain criteria
- Developers can create their own `Slot` validations

resolves #1